### PR TITLE
Some updates for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ clean:
 ensure:
 	yarn && yarn --cwd stencil
 
-.PHONY: start
-start:
+.PHONY: serve
+serve:
 	yarn start
 
 .PHONY: build

--- a/stencil/package.json
+++ b/stencil/package.json
@@ -4,7 +4,7 @@
     "private": "true",
     "scripts": {
         "build": "stencil build",
-        "start": "stencil build --dev --watch",
+        "start": "stencil build --dev --watch --serve",
         "test": "stencil test --spec --e2e",
         "test.watch": "stencil test --spec --e2e --watchAll",
         "generate": "stencil generate"

--- a/stencil/src/index.html
+++ b/stencil/src/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
     <title>Stencil Component Starter</title>
-    <script type="module" src="/build/components.esm.js" defer></script>
-    <script nomodule src="/build/components.js" defer></script>
+    <script type="module" src="/build/app.esm.js"></script>
+    <script nomodule src="/build/app.js"></script>
 </head>
 <body>
     <style>

--- a/stencil/stencil.config.ts
+++ b/stencil/stencil.config.ts
@@ -9,6 +9,10 @@ export const config: Config = {
             type: "dist-custom-elements-bundle",
             dir: "./dist",
         },
+        {
+            type: "www",
+            buildDir: "./build",
+        }
     ],
     plugins: [
         sass(),


### PR DESCRIPTION
Just started working in theme, and had to make some changes locally to enable local dev - please let me know if I'm off-base on any of these, or if they will conflict with other flows, since I'm just jumping in.

### Changes:

- `start` script needed a `--serve` flag to start Stencil's dev server
- The index.html dev playground wasn't loading custom components, because it was 404ing on the source.  I added a second output target with a build directory, and then updated the file names in the scripts, and the components work as expected. 