### PR TITLE
Support an optional label on multi select forms

### DIFF
--- a/stencil/src/components/contact-us-form/contact-us-form.tsx
+++ b/stencil/src/components/contact-us-form/contact-us-form.tsx
@@ -4,6 +4,7 @@ import { getQueryVariable } from "../../util/util";
 
 interface ContactUsItem {
     key: string;
+    label?: string;
     hubspot_form_id: string;
 }
 
@@ -35,7 +36,8 @@ export class ContactUsForm {
     componentWillLoad() {
         this.parsedItems = JSON.parse(this.items).map((item: ContactUsItem) => {
             return {
-                key: item.key.charAt(0).toUpperCase() + item.key.slice(1),
+                key: item.key,
+                label: item.label ? item.label : item.key.charAt(0).toUpperCase() + item.key.slice(1),
                 hubspotFormId: item.hubspot_form_id
             };
         });

--- a/stencil/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
+++ b/stencil/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
@@ -2,6 +2,7 @@ import { Component, Prop, State, Element, h } from "@stencil/core";
 
 export interface MultiSelectFormItem {
     key: string | Date;
+    label?: string;
     hubspotFormId: string;
 }
 
@@ -97,7 +98,9 @@ export class PulumiMultiSelectForm {
                         <select class={this.selectClass || ""} onInput={(event: any) => this.handleSelectChange(event.target.value)}>
                             {this.items.map((item) => {
                                 const isSelected = item.hubspotFormId === selectedFormId;
-                                return <option value={item.hubspotFormId} selected={isSelected}>{item.key}</option>;
+                                return <option value={item.hubspotFormId} selected={isSelected}>
+                                    { item.label ? item.label : item.key }
+                                </option>;
                             })}
                         </select>
                     </span>


### PR DESCRIPTION
This PR adds support for optional labels on the multi select HubSpot forms. 

Part of https://github.com/pulumi/pulumi-service/issues/7474