### PR TITLE
Restore z-index to header menu

### DIFF
--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -206,7 +206,7 @@
                     @apply relative cursor-pointer;
 
                     .header-nav-drop-down-menu {
-                        @apply w-full absolute hidden min-w-max pt-6 top-0;
+                        @apply w-full absolute hidden min-w-max pt-6 top-0 z-10;
 
                         ul {
                             @apply bg-white text-left rounded shadow-xl py-2 whitespace-nowrap;


### PR DESCRIPTION
I overlooked [this line](https://github.com/pulumi/pulumi-hugo/commit/95ab3dc1c1a8621e83603d426a401b69c5501cd2#diff-d0fb741f2f029a01e6f57edfb14f569bba0806d1b23211151656368634d73552R115) in https://github.com/pulumi/theme/pull/20. This change should fix it up.