### PR TITLE
Always merge to release

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,4 +27,11 @@ jobs:
         with:
           file_pattern: assets/js/bundle.js assets/css/bundle.css
           commit_message: Commit asset bundles
-          branch: release
+
+      - name: Merge into release
+        uses: everlytic/branch-merge@1.1.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_ref: ${{ github.ref }}
+          target_branch: release
+          commit_message_template: "[Automated] Merge {source_ref} into {target_branch}"


### PR DESCRIPTION
With #37, I mistakenly assumed [`git-auto-commit-action`](https://github.com/stefanzweifel/git-auto-commit-action) would pretty much always merge `master` into `release`, but there are situations in which that might not be the case. Because that action only commits when it detects changes to the working tree, a developer could run `make build` locally, for example, check in the resulting CSS and JS bundles, and prevent those bundles from ever making it to the `release` branch, as the action (which runs that same command) wouldn't detect that anything had changed.

This PR restores the previous behavior of `git-auto-commit-action` -- i.e., to commit back to `master` -- and adds one more step to the workflow to merge `master` into `release` at the end of every workflow run to ensure the `release` branch is always current _and_ has the right set of CSS and JS assets. ([See here](https://github.com/cnunciato/actions-testing) for a little testing I did with this today to make sure it actually did what I thought it would this time.)