### PR TITLE
Space subnav items evenly

### DIFF
--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -14315,7 +14315,7 @@ nav.nav-section-sticky ul{
   list-style-type: none;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: space-around;
+  justify-content: space-evenly;
   padding: 0px;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;

--- a/src/scss/_section-nav.scss
+++ b/src/scss/_section-nav.scss
@@ -4,7 +4,7 @@ nav {
         @apply bg-white text-base text-black px-4;
 
         ul {
-            @apply flex list-none justify-around items-center flex-wrap text-base py-2 p-0;
+            @apply flex list-none justify-evenly items-center flex-wrap text-base py-2 p-0;
 
             @screen md {
                 @apply text-base py-0;


### PR DESCRIPTION
This change adjusts the spacing between nav items (on case studies pages, for example) to bring them a bit closer together. It could still be improved, but is a bit better than what we have now, and addresses a somewhat pressing need.

https://user-images.githubusercontent.com/274700/156664568-630dc66b-d038-4bf0-aea4-29941d53ceaa.mov

Only applies to pages where subnavs like these ☝️ are in use.