### PR TITLE
Use pulumi-bot for auto-commits

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,11 +27,12 @@ jobs:
         with:
           file_pattern: assets/js/bundle.js assets/css/bundle.css
           commit_message: Commit asset bundles
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
 
       - name: Merge into release
         uses: everlytic/branch-merge@1.1.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
           source_ref: ${{ github.ref }}
           target_branch: release
           commit_message_template: "[Automated] Merge {source_ref} into {target_branch}"


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi-hugo/pull/1138, this change uses `pulumi-bot` for auto-commits to `master` and `release`.