### PR TITLE
Try loading jQuery from cdnjs

### DIFF
--- a/layouts/partials/assets.html
+++ b/layouts/partials/assets.html
@@ -1,8 +1,9 @@
 <!-- Use this partial to pull the JS and CSS bundles into your project. -->
 
-<script src="https://code.jquery.com/jquery-3.3.1.min.js"
-    integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
-    crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" 
+    integrity="sha512-+NqPlbbtM1QqiK8ZAo4Yrj2c4lNQoGv8P79DPtKzj++l5jnN39rHA/xsqn8zE9l0uSoxaCdrOgFs6yjyfbBxSg==" 
+    crossorigin="anonymous" 
+    referrerpolicy="no-referrer"></script>
 
 {{ $js := resources.Get "js/bundle.js" | fingerprint }}
 <script src="{{ $js.RelPermalink }}" defer></script>


### PR DESCRIPTION
Apparently some users are having trouble loading jQuery from `code.jquery.com` because of software running within their Chrome and Edge browsers. This change loads jQuery from a different CDN that doesn't appear to be getting blocked by this software.