### PR TITLE
Use the bot token to check out the repo on push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,6 +15,8 @@ jobs:
 
             - name: Check out branch
               uses: actions/checkout@v2
+              with:
+                token: ${{ secrets.PULUMI_BOT_TOKEN }}
 
             - name: Build assets
               run: |
@@ -27,7 +29,6 @@ jobs:
               with:
                   file_pattern: assets/js/bundle.js assets/css/bundle.css
                   commit_message: Commit asset bundles
-                  token: ${{ secrets.PULUMI_BOT_TOKEN }}
 
             - name: Merge into release
               uses: everlytic/branch-merge@1.1.2


### PR DESCRIPTION
I suspect this is because we aren't using the bot token to check out the repo (as we are in pulumi-hugo). 🤞 