### PR TITLE
Highlight top-nav links in purple on hover

### DIFF
--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -3580,8 +3580,8 @@ ul.glossary{
     padding-left: 1rem
   }
 
-  .header-container .desktop-menu li:not(.header-dropdown-item):hover a, .header-container .desktop-menu li:not(.header-dropdown-item):hover .dropdown-title{
-    opacity: 0.5;
+  .header-container .desktop-menu li:not(.header-dropdown-item):hover a,.header-container .desktop-menu li:not(.header-dropdown-item):hover .dropdown-title{
+    color:#7b61ff
   }
 
   .header-container .desktop-menu li:not(.header-dropdown-item).header-nav-item-drop-down{
@@ -3616,8 +3616,12 @@ ul.glossary{
     margin-bottom: 0.25rem
   }
 
+  .header-container .desktop-menu li:not(.header-dropdown-item).header-nav-item-drop-down .header-nav-drop-down-menu ul a{
+    color:#2f3032
+  }
+
   .header-container .desktop-menu li:not(.header-dropdown-item).header-nav-item-drop-down .header-nav-drop-down-menu ul a:hover{
-    opacity: 1
+    color:#7b61ff
   }
 
   .header-container .desktop-menu li:not(.header-dropdown-item).header-nav-item-drop-down .dropdown-menu-caret{

--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -3581,7 +3581,7 @@ ul.glossary{
   }
 
   .header-container .desktop-menu li:not(.header-dropdown-item):hover a,.header-container .desktop-menu li:not(.header-dropdown-item):hover .dropdown-title{
-    color:#7b61ff
+    color:#805ac3
   }
 
   .header-container .desktop-menu li:not(.header-dropdown-item).header-nav-item-drop-down{
@@ -3621,7 +3621,7 @@ ul.glossary{
   }
 
   .header-container .desktop-menu li:not(.header-dropdown-item).header-nav-item-drop-down .header-nav-drop-down-menu ul a:hover{
-    color:#7b61ff
+    color:#805ac3
   }
 
   .header-container .desktop-menu li:not(.header-dropdown-item).header-nav-item-drop-down .dropdown-menu-caret{

--- a/src/scss/_colors.scss
+++ b/src/scss/_colors.scss
@@ -1,6 +1,8 @@
 $black: #000;
 $white: #fff;
 
+$indigo: #7b61ff;
+
 $brand: (
     "yellow": #f7bf2a,
     "salmon": #f26e7e,

--- a/src/scss/_colors.scss
+++ b/src/scss/_colors.scss
@@ -1,8 +1,6 @@
 $black: #000;
 $white: #fff;
 
-$indigo: #7b61ff;
-
 $brand: (
     "yellow": #f7bf2a,
     "salmon": #f26e7e,

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -179,7 +179,7 @@
                 &:hover {
                     a,
                     .dropdown-title {
-                        @apply opacity-50;
+                        color: #7b61ff;
                     }
                 }
 
@@ -197,8 +197,9 @@
                             }
 
                             a {
+                                color: theme("colors.gray.800");
                                 &:hover {
-                                    @apply opacity-100;
+                                    color: #7b61ff;
                                 }
                             }
                         }

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -179,7 +179,7 @@
                 &:hover {
                     a,
                     .dropdown-title {
-                        color: #7b61ff;
+                        color: $indigo;
                     }
                 }
 
@@ -199,7 +199,7 @@
                             a {
                                 color: theme("colors.gray.800");
                                 &:hover {
-                                    color: #7b61ff;
+                                    color: $indigo;
                                 }
                             }
                         }

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -179,7 +179,7 @@
                 &:hover {
                     a,
                     .dropdown-title {
-                        color: $indigo;
+                        color: $brand-violet;
                     }
                 }
 
@@ -199,7 +199,7 @@
                             a {
                                 color: theme("colors.gray.800");
                                 &:hover {
-                                    color: $indigo;
+                                    color: $brand-violet;
                                 }
                             }
                         }


### PR DESCRIPTION
This PR addresses the first part of https://github.com/pulumi/pulumi-hugo/issues/427. I will add in the additional drop down menu options in a following PR.

This change removes the grayed out look of the menus when being hovered over and instead highlights the hovered link in purple.

![topnav1](https://user-images.githubusercontent.com/16751381/166060455-65b7a9b8-5211-4df8-a85a-63de7f24e0e8.gif)
