### PR TITLE
Make learn dropdown wider

### DIFF
--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -3712,7 +3712,7 @@ ul.glossary{
 
   .header-container .desktop-menu li:not(.header-dropdown-item).header-nav-item-drop-down .learn{
     right: -12rem;
-    min-width:65ch
+    min-width:67ch
   }
 
   .header-container .desktop-menu li:not(.header-dropdown-item).header-nav-item-drop-down .dropdown-menu-caret{

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -260,7 +260,7 @@
 
                     .learn {
                         @apply -right-48;
-                        min-width: 65ch;
+                        min-width: 67ch;
                     }
 
                     .dropdown-menu-caret {


### PR DESCRIPTION
fixes: [Issue](https://github.com/pulumi/pulumi-hugo/issues/1485)

I went ahead and made the change to make the learn drop down 2 characters wider in order to prevent the text from wrapping.

![Screenshot from 2022-05-05 22-04-09](https://user-images.githubusercontent.com/16751381/167070595-12dc3819-f4f5-43b3-98b3-e55f5078dd01.png)
