### PR TITLE
Fix text wrapping on learn menu

### DIFF
--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -3712,7 +3712,7 @@ ul.glossary{
 
   .header-container .desktop-menu li:not(.header-dropdown-item).header-nav-item-drop-down .learn{
     right: -12rem;
-    min-width:67ch
+    min-width:69ch
   }
 
   .header-container .desktop-menu li:not(.header-dropdown-item).header-nav-item-drop-down .dropdown-menu-caret{

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -260,7 +260,7 @@
 
                     .learn {
                         @apply -right-48;
-                        min-width: 67ch;
+                        min-width: 69ch;
                     }
 
                     .dropdown-menu-caret {


### PR DESCRIPTION
When hovering over resources item on learn menu, the increase in font weight is causing the text to wrap onto two lines. I made it a little wider to prevent this from happening.
![Screenshot from 2022-05-06 09-16-18](https://user-images.githubusercontent.com/16751381/167172238-9d03259c-37af-4f2a-9f75-4f8ea32713b1.png)
