### PR TITLE
Learn page fixes

### DIFF
--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -4107,6 +4107,13 @@ ul.glossary{
   text-align: center
 }
 
+@media (min-width: 1024px){
+  .page-hero .page-hero-title h1{
+    font-size:5.25rem;
+    line-height:5.5rem !important
+  }
+}
+
 .aws-dev-day-header{
   background:url("/images/webinar/aws-dev-day/bg-dev-day.jpeg");
   background-size:cover;

--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -4109,8 +4109,8 @@ ul.glossary{
 
 @media (min-width: 1024px){
   .page-hero .page-hero-title h1{
-    font-size:5.25rem;
-    line-height:5.5rem !important
+    font-size:4.5rem;
+    line-height:1.375 !important
   }
 }
 
@@ -12952,6 +12952,10 @@ ul.glossary{
 
 .icon-code-window-blue svg rect{
   fill:#4d5bd9
+}
+
+.learn-h2{
+  font-size:3rem
 }
 
 dl.resources-properties, dl.package-details, dl.tabular{

--- a/src/scss/_hero.scss
+++ b/src/scss/_hero.scss
@@ -113,8 +113,8 @@
         h1 {
             @apply text-center max-w-4xl my-10;
             @screen lg {
-                font-size: 5.25rem;
-                line-height: 5.5rem !important;
+                font-size: 4.5rem;
+                line-height: 1.375 !important;
             }
         }
     }

--- a/src/scss/_hero.scss
+++ b/src/scss/_hero.scss
@@ -112,6 +112,10 @@
 
         h1 {
             @apply text-center max-w-4xl my-10;
+            @screen lg {
+                font-size: 5.25rem;
+                line-height: 5.5rem !important;
+            }
         }
     }
 }

--- a/src/scss/_learn.scss
+++ b/src/scss/_learn.scss
@@ -1,0 +1,3 @@
+.learn-h2 {
+    font-size: 3rem;
+}


### PR DESCRIPTION
Issue: https://github.com/pulumi/pulumi-hugo/issues/1534

See corresponding Hugo PR for preview link - https://github.com/pulumi/pulumi-hugo/pull/1542/

This styling update just adds back the styling that was removed to improve mobile experience. This resulted in making the h1 text on the learn page smaller. I added back the styling that was removed and instead put it behind a breakpoint so that the mobile experience remains unaffected from adding back this change. See https://github.com/pulumi/pulumi-hugo/issues/1534#issuecomment-1132991097 for more context