### PR TITLE
Add gray underline, support alignment and justification

### DIFF
--- a/src/scss/components/_tabs.scss
+++ b/src/scss/components/_tabs.scss
@@ -3,20 +3,24 @@ pulumi-tabs {
     // The tab list.
     &::part(tabs) {
         // If we don't to this, we'll get a flash of unstyled content.
-        @apply list-none p-0 mb-2 overflow-scroll;
-
-        @screen md {
-            @apply justify-center;
-        }
+        @apply list-none p-0 mb-2 overflow-scroll flex;
     }
 
     // An individual tab.
     &::part(tab) {
-        @apply font-display text-base bg-transparent;
-        border-bottom: 2px solid transparent;
+        @apply font-display bg-transparent flex-auto;
+        border-bottom: 2px solid theme("colors.gray.300");
+    }
 
-        @screen md {
-            @apply text-lg;
+    &[justify="center"] {
+        &::part(tabs) {
+            @screen sm {
+                @apply justify-center;
+            }
+        }
+
+        &::part(tab) {
+            @apply flex-none;
         }
     }
 

--- a/stencil/src/components/tabs/tabs.tsx
+++ b/stencil/src/components/tabs/tabs.tsx
@@ -19,9 +19,15 @@ import { Component, Element, Event, EventEmitter, h, State } from "@stencil/core
             width: auto;
             list-style-type: none;
         }
+        li {
+            display: flex;
+            justify-content: center;
+        }
         li a {
             cursor: pointer;
-            display: inline-flex;
+            display: flex;
+            justify-content: center;
+            flex: 1;
             text-align: center;
             white-space: nowrap;
         }


### PR DESCRIPTION
This change makes a few tweaks to the tabs component to make it easier to style at the element level (i.e., so you don't have to write custom CSS to address the individual parts). Whereas now, tabs are center-justified no matter what, which you may not always want, now they're full-justified by default (like they are with the language chooser), and you can specify an optional `justify` property to center them on the page:

```html
<pulumi-tabs justify="center"></pulumi-tabs>
```

Also adds a two-pixel gray underline (again to match the styling of the chooser), and lets tab labels inherit the parent's text size, rather than be hard-coded as they are now based on screen width.

By default:

![image](https://user-images.githubusercontent.com/274700/179626692-1b8e227f-031a-4da6-8d9a-3ab01955ef08.png)

With `justify="center"`:

![image](https://user-images.githubusercontent.com/274700/179625681-5b0ad53b-d5e5-4c7d-ac7c-c0b80ba1aa71.png)




