### PR TITLE
Style definition lists in the docs

### DIFF
--- a/src/scss/_lists.scss
+++ b/src/scss/_lists.scss
@@ -1,7 +1,9 @@
 dl {
     &.resources-properties,
     &.package-details,
-    &.tabular {
+    &.tabular,
+    body.section-docs &
+    {
         @apply mb-8 mt-4 p-1 flex flex-col items-start items-stretch bg-gray-100 border rounded border-gray-300 text-sm text-gray-700;
 
         @screen lg {


### PR DESCRIPTION
This change allows us to write [Markdown definition lists](https://www.markdownguide.org/extended-syntax/#definition-lists) on any page in the docs:

```markdown
indexDocument
: The filename to use for top-level pages. Defaults to `index.html`.

errorDocument
: The filename to use for error pages (e.g., 404s). Defaults to `error.html`.

site
: The name of the folder containing the files of the website. Defaults to `site`, which is included with the blueprint.
```

... and have those lists inherit the same responsive styling we use for definition lists elsewhere, such as in our API docs:

![image](https://user-images.githubusercontent.com/274700/186787991-afba7bca-debc-40dc-9e5c-10df6aef943a.png)

Doesn't quite solve for [responsive tables](https://github.com/pulumi/pulumi-hugo/issues/2594), but does give us a way to write nicer-looking property lists like these and still keep our source content tidy.