### PR TITLE
Add CSS for templates

### DIFF
--- a/layouts/partials/assets.html
+++ b/layouts/partials/assets.html
@@ -8,7 +8,7 @@
 {{ $js := resources.Get "js/bundle.js" | fingerprint }}
 <script src="{{ $js.RelPermalink }}" defer></script>
 
-{{ $nonMarketingSections := slice "docs" "registry" "blog" "learn" "authors" "tags" "legal" }}
+{{ $nonMarketingSections := slice "docs" "registry" "blog" "learn" "templates" "authors" "tags" "legal" }}
 {{ if in $nonMarketingSections .Section }}
 {{ else }}
     {{ $marketingCss := resources.Get "css/marketing.css" | fingerprint }}

--- a/src/scss/_lists.scss
+++ b/src/scss/_lists.scss
@@ -2,7 +2,8 @@ dl {
     &.resources-properties,
     &.package-details,
     &.tabular,
-    body.section-docs &
+    body.section-docs &,
+    body.section-templates &
     {
         @apply mb-8 mt-4 p-1 flex flex-col items-start items-stretch bg-gray-100 border rounded border-gray-300 text-sm text-gray-700;
 


### PR DESCRIPTION
This adds a bit of CSS for the Templates section -- slight adjustments to heading sizes (mainly to work around inheriting the default styling of the rest of the marketing section, which doesn't quite fit here -- hence my adding a `_templates` include, much like we've done for Learn) and pulling in list styling and .. well, that's pretty much it.

These minor adjustments need to be merged before the rest of the templates work can ship (currently queued up in https://github.com/pulumi/pulumi-hugo/pull/1891), so hopefully there nothing too controversial here.