### PR TITLE
Remove list styles from docs

### DIFF
--- a/src/scss/_lists.scss
+++ b/src/scss/_lists.scss
@@ -2,7 +2,6 @@ dl {
     &.resources-properties,
     &.package-details,
     &.tabular,
-    body.section-docs &,
     body.section-templates &
     {
         @apply mb-8 mt-4 p-1 flex flex-col items-start items-stretch bg-gray-100 border rounded border-gray-300 text-sm text-gray-700;


### PR DESCRIPTION
These styles are being picked up unintentionally by the Python docs. Since we aren't actually using them in the docs section yet (they were added for the templates pages, which we ended up giving their own section), we can remove them for now.

Feel free to merge on approval. 🚀 